### PR TITLE
fix interface codegen with dagger.DaggerObject

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -1,18 +1,18 @@
 {
   "name": "Usage",
-  "engineVersion": "v0.18.5",
+  "engineVersion": "v0.18.6",
   "sdk": {
     "source": "go"
   },
-  "source": "usage",
   "dependencies": [
     {
       "name": "Example",
-      "source": "./usage/implementation"
+      "source": "usage/implementation"
     },
     {
       "name": "MyModule",
-      "source": "./usage/interface"
+      "source": "usage/interface"
     }
-  ]
+  ],
+  "source": "usage"
 }

--- a/usage/implementation/dagger.json
+++ b/usage/implementation/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "Example",
-  "engineVersion": "v0.18.5",
+  "engineVersion": "v0.18.6",
   "sdk": {
     "source": "go"
   }

--- a/usage/implementation/main.go
+++ b/usage/implementation/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-    "dagger/example/internal/dagger"
+	"dagger/example/internal/dagger"
 	"fmt"
 )
 

--- a/usage/interface/dagger.json
+++ b/usage/interface/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "MyModule",
-  "engineVersion": "v0.18.5",
+  "engineVersion": "v0.18.6",
   "sdk": {
     "source": "go"
   }

--- a/usage/interface/main.go
+++ b/usage/interface/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
+	"dagger/my-module/internal/dagger"
 )
 
 type MyModule struct{}
 
 type Fooer interface {
-	DaggerObject
+	dagger.DaggerObject
 	Foo(ctx context.Context, bar int) (string, error)
 	HasBar(ctx context.Context) (bool, error)
 	Lint(dir *dagger.Directory, pass bool) *dagger.Directory

--- a/usage/interface/main.go
+++ b/usage/interface/main.go
@@ -8,7 +8,7 @@ import (
 type MyModule struct{}
 
 type Fooer interface {
-	dagger.DaggerObject
+	DaggerObject
 	Foo(ctx context.Context, bar int) (string, error)
 	HasBar(ctx context.Context) (bool, error)
 	Lint(dir *dagger.Directory, pass bool) *dagger.Directory

--- a/usage/main.go
+++ b/usage/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"dagger/usage/internal/dagger"
 )
 
 type Usage struct{}


### PR DESCRIPTION
~~Looks like the root cause of the failing codegen was `DaggerObject` -> `dagger.DaggerObject`. For some reason that made codegen fail so hard that the errors were completely unrelated!~~

I guess it was just the missing imports!